### PR TITLE
Fix build.sh to use Python executable found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv
-venv/
+venv*/
 ENV/
 
 # Spyder project settings
@@ -99,3 +99,8 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+#Plugins
+Plugins/
+!Plugins/default.py
+!Plugins/save.py

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ VIRTUAL_ENV_ACTIVE=$($PYTHON_EXEC -c "import sys; print(hasattr(sys, 'real_prefi
 
 if [ $VIRTUAL_ENV_ACTIVE = "False" ]; then
     if [ ! -d "./venv/bin" ]; then
-        python -m "venv" ./venv
+        $PYTHON_EXEC -m "venv" ./venv
     fi
     source "./venv/bin/activate"
     pip install -r requirements.txt


### PR DESCRIPTION
Just a small couple of fixes.  
- The build.sh wasn't using the found executable
- Added a couple of things to the git ignore to not include Plugins not named default or save
- Also ignore any directory starting with venv (I like to name my directories for the python version I am using e.g. venv3.8)